### PR TITLE
npm install @ PrePublish

### DIFF
--- a/src/WebApplication2/project.json
+++ b/src/WebApplication2/project.json
@@ -52,6 +52,7 @@
   },
 
   "scripts": {
+	"prepublish": [ "npm install" ],
     "postpublish": [ "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%" ]
   }
 }


### PR DESCRIPTION
### Running `npm install` during publish

It allows the project to get easily deployed on Cloud services like Azure and there won't be any need to run that command manually